### PR TITLE
Improve logging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,20 +1,20 @@
 stages:
-    - test
-    - deploy
+  - test
+  - deploy
 
 phpstan:
-    stage: test
-    image: registry.networkteam.com/networkteam/build/php81
-    script:
-        - composer phpstan
+  stage: test
+  image: registry.networkteam.com/networkteam/build/php81
+  script:
+    - composer phpstan
 
 deploy:
-    stage: deploy
-    image: curlimages/curl:7.74.0
-    script:
-        - 'curl -v --header "Job-Token: $CI_JOB_TOKEN" --data "tag=$CI_COMMIT_TAG" "https://gitlab.networkteam.com/api/v4/projects/$CI_PROJECT_ID/packages/composer"'
-    only:
-        refs:
-            - tags
-    dependencies:
-        - phpstan
+  stage: deploy
+  image: curlimages/curl:7.74.0
+  script:
+    - 'curl -v --header "Job-Token: $CI_JOB_TOKEN" --data "tag=$CI_COMMIT_TAG" "https://gitlab.networkteam.com/api/v4/projects/$CI_PROJECT_ID/packages/composer"'
+  only:
+    refs:
+      - tags
+  dependencies:
+    - phpstan

--- a/Classes/Command/CacheCommandController.php
+++ b/Classes/Command/CacheCommandController.php
@@ -13,47 +13,47 @@ use Neos\Cache\Backend\NullBackend;
 class CacheCommandController extends \Neos\Flow\Cli\CommandController
 {
 
-	/**
-	 * @var \Neos\Flow\Cache\CacheManager
-	 * @Flow\Inject
-	 */
-	protected $cacheManager;
+    /**
+     * @var \Neos\Flow\Cache\CacheManager
+     * @Flow\Inject
+     */
+    protected $cacheManager;
 
-	/**
-	 * @var \Neos\Flow\Configuration\ConfigurationManager
-	 * @Flow\Inject
-	 */
-	protected $configurationManager;
+    /**
+     * @var \Neos\Flow\Configuration\ConfigurationManager
+     * @Flow\Inject
+     */
+    protected $configurationManager;
 
-	/**
-	 * Clears all non file caches
-	 */
-	public function clearNonFileCachesCommand(): void
-	{
-		$caches = $this->cacheManager->getCacheConfigurations();
-		foreach ($caches as $name => $configuration) {
-			$cache = $this->cacheManager->getCache($name);
-			$backend = $cache->getBackend();
-			if (!$backend instanceof SimpleFileBackend &&
-				!$backend instanceof NullBackend &&
-				!$backend instanceof TransientMemoryBackend
-			) {
-				$cache->flush();
-				$this->outputLine(sprintf('Flushed cache %s', $name));
-			}
-		}
-	}
+    /**
+     * Clears all non file caches
+     */
+    public function clearNonFileCachesCommand(): void
+    {
+        $caches = $this->cacheManager->getCacheConfigurations();
+        foreach ($caches as $name => $configuration) {
+            $cache = $this->cacheManager->getCache($name);
+            $backend = $cache->getBackend();
+            if (!$backend instanceof SimpleFileBackend &&
+                !$backend instanceof NullBackend &&
+                !$backend instanceof TransientMemoryBackend
+            ) {
+                $cache->flush();
+                $this->outputLine(sprintf('Flushed cache %s', $name));
+            }
+        }
+    }
 
-	/**
-	 * Refresh configuration cache (flush and load again)
-	 */
-	public function refreshConfigCommand(): void
-	{
-		try {
-			$this->configurationManager->refreshConfiguration();
-			$this->outputLine('Configuration has been flushed and loaded again.');
-		} catch (\Exception $e) {
-			$this->outputLine(sprintf('Failed: %s', $e->getMessage()));
-		}
-	}
+    /**
+     * Refresh configuration cache (flush and load again)
+     */
+    public function refreshConfigCommand(): void
+    {
+        try {
+            $this->configurationManager->refreshConfiguration();
+            $this->outputLine('Configuration has been flushed and loaded again.');
+        } catch (\Exception $e) {
+            $this->outputLine(sprintf('Failed: %s', $e->getMessage()));
+        }
+    }
 }

--- a/Classes/Domain/DataTransferObject/ListViewConfiguration.php
+++ b/Classes/Domain/DataTransferObject/ListViewConfiguration.php
@@ -5,7 +5,6 @@ namespace Networkteam\Util\Domain\DataTransferObject;
 /***************************************************************
  *  (c) 2013 networkteam GmbH - all rights reserved
  ***************************************************************/
-
 class ListViewConfiguration
 {
     /**
@@ -131,9 +130,9 @@ class ListViewConfiguration
 
     public function setSortDirections(array $sortDirections): void
     {
-		foreach ($sortDirections as $propertyName => $direction) {
-			$this->setSortDirection($propertyName, $direction);
-		}
+        foreach ($sortDirections as $propertyName => $direction) {
+            $this->setSortDirection($propertyName, $direction);
+        }
     }
 
     public function getSortDirections(): array
@@ -223,7 +222,7 @@ class ListViewConfiguration
     }
 
     /**
-	 * Replaces "_" by "." in property names
+     * Replaces "_" by "." in property names
      */
     public function getSortDirectionsWithPropertyPath(): array
     {

--- a/Classes/Domain/Repository/AbstractFilterableRepository.php
+++ b/Classes/Domain/Repository/AbstractFilterableRepository.php
@@ -162,7 +162,7 @@ abstract class AbstractFilterableRepository extends \Neos\Flow\Persistence\Doctr
     protected function getOrderings(ListViewConfiguration $listViewConfiguration): array
     {
         return array_filter($listViewConfiguration->getSortDirections(), function ($propertyPath) {
-             return $propertyPath !== '*' && !empty($propertyPath);
+            return $propertyPath !== '*' && !empty($propertyPath);
         }, ARRAY_FILTER_USE_KEY);
     }
 }

--- a/Classes/Log/Backend/ConsoleBackend.php
+++ b/Classes/Log/Backend/ConsoleBackend.php
@@ -44,19 +44,20 @@ class ConsoleBackend extends AbstractBackend
     public function open(): void
     {
         $this->severityLabels = [
-            LOG_EMERG   => 'EMERGENCY',
-            LOG_ALERT   => 'ALERT    ',
-            LOG_CRIT    => 'CRITICAL ',
-            LOG_ERR     => 'ERROR    ',
+            LOG_EMERG => 'EMERGENCY',
+            LOG_ALERT => 'ALERT    ',
+            LOG_CRIT => 'CRITICAL ',
+            LOG_ERR => 'ERROR    ',
             LOG_WARNING => 'WARNING  ',
-            LOG_NOTICE  => 'NOTICE   ',
-            LOG_INFO    => 'INFO     ',
-            LOG_DEBUG   => 'DEBUG    ',
+            LOG_NOTICE => 'NOTICE   ',
+            LOG_INFO => 'INFO     ',
+            LOG_DEBUG => 'DEBUG    ',
         ];
 
         $this->streamHandle = fopen('php://' . $this->streamName, 'w');
         if (!is_resource($this->streamHandle)) {
-            throw new CouldNotOpenResourceException('Could not open stream "' . $this->streamName . '" for write access.', 1310986609);
+            throw new CouldNotOpenResourceException('Could not open stream "' . $this->streamName . '" for write access.',
+                1310986609);
         }
     }
 
@@ -72,8 +73,14 @@ class ConsoleBackend extends AbstractBackend
      * @return void
      * @api
      */
-    public function append(string $message, int $severity = LOG_INFO, $additionalData = null, string $packageKey = null, string $className = null, string $methodName = null): void
-    {
+    public function append(
+        string $message,
+        int $severity = LOG_INFO,
+        $additionalData = null,
+        string $packageKey = null,
+        string $className = null,
+        string $methodName = null
+    ): void {
         if ($severity > $this->severityThreshold) {
             return;
         }

--- a/Classes/Log/MailerLoggerInterface.php
+++ b/Classes/Log/MailerLoggerInterface.php
@@ -4,7 +4,6 @@ namespace Networkteam\Util\Log;
 /***************************************************************
  *  (c) 2013 networkteam GmbH - all rights reserved
  ***************************************************************/
-
 interface MailerLoggerInterface extends \Psr\Log\LoggerInterface
 {
 

--- a/Classes/Log/ThrowableStorage/ConsoleStorage.php
+++ b/Classes/Log/ThrowableStorage/ConsoleStorage.php
@@ -14,130 +14,132 @@ use Neos\Flow\ObjectManagement\ObjectManagerInterface;
 final class ConsoleStorage implements ThrowableStorageInterface
 {
 
-	/**
-	 * @var false|resource
-	 */
-	protected $streamHandle;
+    /**
+     * @var false|resource
+     */
+    protected $streamHandle;
 
-	/**
-	 * @throws CouldNotOpenResourceException
-	 */
-	public function __construct(string $streamName)
-	{
-		$this->streamHandle = fopen($streamName, 'w');
+    /**
+     * @throws CouldNotOpenResourceException
+     */
+    public function __construct(string $streamName)
+    {
+        $this->streamHandle = fopen($streamName, 'w');
 
-		if (!is_resource($this->streamHandle)) {
-			throw new CouldNotOpenResourceException(sprintf('Could not open stream "%s" for write access', $streamName), 20230726162106);
-		}
-	}
+        if (!is_resource($this->streamHandle)) {
+            throw new CouldNotOpenResourceException(sprintf('Could not open stream "%s" for write access', $streamName),
+                20230726162106);
+        }
+    }
 
-	public static function createWithOptions(array $options): ThrowableStorageInterface
-	{
-		if (!array_key_exists('streamName', $options)) {
-			throw new \Exception('A stream name must be set');
-		}
+    public static function createWithOptions(array $options): ThrowableStorageInterface
+    {
+        if (!array_key_exists('streamName', $options)) {
+            throw new \Exception('A stream name must be set');
+        }
 
-		$streamName = $options['streamName'];
+        $streamName = $options['streamName'];
 
-		if (strpos($streamName, 'php://') === 0) {
-			$streamName = substr($streamName, 6);
-		}
-		return new static('php://' . $streamName);
-	}
+        if (strpos($streamName, 'php://') === 0) {
+            $streamName = substr($streamName, 6);
+        }
+        return new static('php://' . $streamName);
+    }
 
-	public function logThrowable(\Throwable $throwable, array $additionalData = [])
-	{
-		if (Bootstrap::$staticObjectManager instanceof ObjectManagerInterface) {
-			$bootstrap = Bootstrap::$staticObjectManager->get(Bootstrap::class);
-			/** @var ConfigurationManager $configurationManager */
-			$configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
+    public function logThrowable(\Throwable $throwable, array $additionalData = [])
+    {
+        if (Bootstrap::$staticObjectManager instanceof ObjectManagerInterface) {
+            $bootstrap = Bootstrap::$staticObjectManager->get(Bootstrap::class);
+            /** @var ConfigurationManager $configurationManager */
+            $configurationManager = $bootstrap->getEarlyInstance(ConfigurationManager::class);
 
-			$serviceContext = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'Networkteam.Util.serviceContext');
-		} else { // @phpstan-ignore-line
-			$serviceContext = 'neos-flow';
-		}
+            $serviceContext = $configurationManager->getConfiguration(ConfigurationManager::CONFIGURATION_TYPE_SETTINGS,
+                'Networkteam.Util.serviceContext');
+        } else { // @phpstan-ignore-line
+            $serviceContext = 'neos-flow';
+        }
 
-		$data = [
-			'eventTime' => (new \DateTime('now'))->format(DATE_RFC3339),
-			'serviceContext' => $serviceContext,
-			'message' => sprintf('PHP Warning: %s', $throwable->getMessage()),
-			'stackTrace' => $throwable->getTraceAsString(),
-			'context' => [
-				'httpRequest' => $this->getHttpRequestContext(),
-				'reportLocation' => [
-					'filePath' => $throwable->getFile(),
-					'lineNumber' => $throwable->getLine(),
-					'functionName' => self::getFunctionNameForTrace($throwable->getTrace()),
-				],
-			]
-		];
+        $data = [
+            'eventTime' => (new \DateTime('now'))->format(DATE_RFC3339),
+            'serviceContext' => $serviceContext,
+            'message' => sprintf('PHP Warning: %s', $throwable->getMessage()),
+            'stackTrace' => $throwable->getTraceAsString(),
+            'context' => [
+                'httpRequest' => $this->getHttpRequestContext(),
+                'reportLocation' => [
+                    'filePath' => $throwable->getFile(),
+                    'lineNumber' => $throwable->getLine(),
+                    'functionName' => self::getFunctionNameForTrace($throwable->getTrace()),
+                ],
+            ]
+        ];
 
-		$output = json_encode($data);
+        $output = json_encode($data);
 
-		if (is_resource($this->streamHandle)) {
-			fwrite($this->streamHandle, $output . PHP_EOL);
-		}
+        if (is_resource($this->streamHandle)) {
+            fwrite($this->streamHandle, $output . PHP_EOL);
+        }
 
-		return $output;
-	}
+        return $output;
+    }
 
-	/**
-	 * @return mixed[]
-	 */
-	public function getHttpRequestContext(): array
-	{
-		if (!(Bootstrap::$staticObjectManager instanceof ObjectManagerInterface)) {
-			return [];
-		}
+    /**
+     * @return mixed[]
+     */
+    public function getHttpRequestContext(): array
+    {
+        if (!(Bootstrap::$staticObjectManager instanceof ObjectManagerInterface)) {
+            return [];
+        }
 
-		$bootstrap = Bootstrap::$staticObjectManager->get(Bootstrap::class);
-		/** @var Bootstrap $bootstrap */
-		$requestHandler = $bootstrap->getActiveRequestHandler();
-		if (!$requestHandler instanceof HttpRequestHandlerInterface) {
-			return [];
-		}
+        $bootstrap = Bootstrap::$staticObjectManager->get(Bootstrap::class);
+        /** @var Bootstrap $bootstrap */
+        $requestHandler = $bootstrap->getActiveRequestHandler();
+        if (!$requestHandler instanceof HttpRequestHandlerInterface) {
+            return [];
+        }
 
-		$request = $requestHandler->getHttpRequest();
+        $request = $requestHandler->getHttpRequest();
 
-		$context = [
-			'method' => $request->getMethod(),
-			'url' => (string)$request->getUri(),
-		];
+        $context = [
+            'method' => $request->getMethod(),
+            'url' => (string)$request->getUri(),
+        ];
 
-		if ($request->hasHeader('User-Agent')) {
-			$context['userAgent'] = $request->getHeader('User-Agent')[0];
-		}
+        if ($request->hasHeader('User-Agent')) {
+            $context['userAgent'] = $request->getHeader('User-Agent')[0];
+        }
 
-		return $context;
-	}
+        return $context;
+    }
 
-	public function setRequestInformationRenderer(\Closure $requestInformationRenderer)
-	{
-		// No backtrace renderer is needed here
-		return $this;
-	}
+    public function setRequestInformationRenderer(\Closure $requestInformationRenderer)
+    {
+        // No backtrace renderer is needed here
+        return $this;
+    }
 
-	public function setBacktraceRenderer(\Closure $backtraceRenderer)
-	{
-		// No backtrace renderer is needed here
-		return $this;
-	}
+    public function setBacktraceRenderer(\Closure $backtraceRenderer)
+    {
+        // No backtrace renderer is needed here
+        return $this;
+    }
 
-	private function getFunctionNameForTrace(?array $trace = null): string
-	{
-		if ($trace === null) {
-			return '<unknown function>';
-		}
-		if (empty($trace[0]['function'])) {
-			return '<none>';
-		}
-		$functionName = [$trace[0]['function']];
-		if (isset($trace[0]['type'])) {
-			$functionName[] = $trace[0]['type'];
-		}
-		if (isset($trace[0]['class'])) {
-			$functionName[] = $trace[0]['class'];
-		}
-		return implode('', array_reverse($functionName));
-	}
+    private function getFunctionNameForTrace(?array $trace = null): string
+    {
+        if ($trace === null) {
+            return '<unknown function>';
+        }
+        if (empty($trace[0]['function'])) {
+            return '<none>';
+        }
+        $functionName = [$trace[0]['function']];
+        if (isset($trace[0]['type'])) {
+            $functionName[] = $trace[0]['type'];
+        }
+        if (isset($trace[0]['class'])) {
+            $functionName[] = $trace[0]['class'];
+        }
+        return implode('', array_reverse($functionName));
+    }
 }

--- a/Classes/Log/WebRequestContext.php
+++ b/Classes/Log/WebRequestContext.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Networkteam\Util\Log;
+
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Http\HttpRequestHandlerInterface;
+use Neos\Flow\ObjectManagement\ObjectManagerInterface;
+
+class WebRequestContext
+{
+    public static function getContext(): ?array
+    {
+        if (!(Bootstrap::$staticObjectManager instanceof ObjectManagerInterface)) {
+            return null;
+        }
+
+        $bootstrap = Bootstrap::$staticObjectManager->get(Bootstrap::class);
+        /** @var Bootstrap $bootstrap */
+        $requestHandler = $bootstrap->getActiveRequestHandler();
+        if (!$requestHandler instanceof HttpRequestHandlerInterface) {
+            return null;
+        }
+
+        $request = $requestHandler->getHttpRequest();
+
+        $context = [
+            'method' => $request->getMethod(),
+            'url' => (string)$request->getUri(),
+        ];
+
+        if ($request->hasHeader('User-Agent')) {
+            $context['userAgent'] = $request->getHeader('User-Agent')[0];
+        }
+
+        $requestId = $_SERVER['X-REQUEST-ID'] ?? $_SERVER['HTTP_X_REQUEST_ID'] ?? null;
+        if ($requestId) {
+            $context['requestId'] = $requestId;
+        }
+
+        return $context;
+    }
+}

--- a/Classes/Mail/AbstractRenderingMessage.php
+++ b/Classes/Mail/AbstractRenderingMessage.php
@@ -7,193 +7,211 @@ namespace Networkteam\Util\Mail;
 
 use Neos\Flow\Annotations as Flow;
 
-abstract class AbstractRenderingMessage implements MailerMessageInterface {
+abstract class AbstractRenderingMessage implements MailerMessageInterface
+{
 
-	/**
-	 * @var mixed
-	 */
-	protected $from;
+    /**
+     * @var mixed
+     */
+    protected $from;
 
-	/**
-	 * @var mixed
-	 */
-	protected $recipient;
+    /**
+     * @var mixed
+     */
+    protected $recipient;
 
-	/**
-	 * @var string
-	 */
-	protected $subject;
+    /**
+     * @var string
+     */
+    protected $subject;
 
-	/**
-	 * @var string
-	 */
-	protected $replyTo;
+    /**
+     * @var string
+     */
+    protected $replyTo;
 
-	/**
-	 * @var string
-	 */
-	protected $templatePathAndFilename;
+    /**
+     * @var string
+     */
+    protected $templatePathAndFilename;
 
-	/**
-	 * @var array
-	 */
-	protected $templateData = array();
+    /**
+     * @var array
+     */
+    protected $templateData = array();
 
-	/**
-	 * @var array
-	 */
-	protected $options = array();
+    /**
+     * @var array
+     */
+    protected $options = array();
 
-	/**
-	 * @var string
-	 */
-	protected $recipientIdentifier = '';
+    /**
+     * @var string
+     */
+    protected $recipientIdentifier = '';
 
-	/**
-	 * @var \Neos\Flow\Configuration\ConfigurationManager
-	 * @Flow\Inject
-	 */
-	protected $configurationManager;
+    /**
+     * @var \Neos\Flow\Configuration\ConfigurationManager
+     * @Flow\Inject
+     */
+    protected $configurationManager;
 
-	/**
-	 * @param string $templatePathAndFilename
-	 */
-	public function __construct($templatePathAndFilename) {
-		$this->options['templatePathAndFilename'] = $templatePathAndFilename;
-	}
+    /**
+     * @param string $templatePathAndFilename
+     */
+    public function __construct($templatePathAndFilename)
+    {
+        $this->options['templatePathAndFilename'] = $templatePathAndFilename;
+    }
 
-	/**
-	 * Returns the message Body, can be either html or text
-	 *
-	 * @return string
-	 */
-	public function getBody() {
-		$view = $this->createStandaloneView();
-		$view->assignMultiple($this->templateData);
+    /**
+     * Returns the message Body, can be either html or text
+     *
+     * @return string
+     */
+    public function getBody()
+    {
+        $view = $this->createStandaloneView();
+        $view->assignMultiple($this->templateData);
 
-		return $view->render();
-	}
+        return $view->render();
+    }
 
-	/**
-	 * @return mixed
-	 */
-	public function getFrom() {
-		return $this->from;
-	}
+    /**
+     * @return mixed
+     */
+    public function getFrom()
+    {
+        return $this->from;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getRecipient() {
-		return $this->recipient;
-	}
+    /**
+     * @return array
+     */
+    public function getRecipient()
+    {
+        return $this->recipient;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getSubject() {
-		return $this->subject;
-	}
+    /**
+     * @return string
+     */
+    public function getSubject()
+    {
+        return $this->subject;
+    }
 
-	/**
-	 * @param array $options
-	 */
-	public function setOptions(array $options) {
-		$this->options = $options;
-	}
+    /**
+     * @param array $options
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+    }
 
-	/**
-	 * @param array $recipient
-	 */
-	public function setRecipient($recipient) {
-		$this->recipient = $recipient;
-	}
+    /**
+     * @param array $recipient
+     */
+    public function setRecipient($recipient)
+    {
+        $this->recipient = $recipient;
+    }
 
-	/**
-	 * @param mixed $from
-	 */
-	public function setFrom($from) {
-		$this->from = $from;
-	}
+    /**
+     * @param mixed $from
+     */
+    public function setFrom($from)
+    {
+        $this->from = $from;
+    }
 
-	/**
-	 * @return mixed
-	 */
-	public function getReplyTo() {
-		return $this->replyTo;
-	}
+    /**
+     * @return mixed
+     */
+    public function getReplyTo()
+    {
+        return $this->replyTo;
+    }
 
-	/**
-	 * @param mixed $replyTo
-	 */
-	public function setReplyTo($replyTo) {
-		$this->replyTo = $replyTo;
-	}
+    /**
+     * @param mixed $replyTo
+     */
+    public function setReplyTo($replyTo)
+    {
+        $this->replyTo = $replyTo;
+    }
 
-	/**
-	 * @param string $subject
-	 */
-	public function setSubject($subject) {
-		$this->subject = $subject;
-	}
+    /**
+     * @param string $subject
+     */
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+    }
 
-	/**
-	 * @param array $templateData
-	 */
-	public function addTemplateData(array $templateData) {
-		$this->templateData = array_merge($this->templateData, $templateData);
-	}
+    /**
+     * @param array $templateData
+     */
+    public function addTemplateData(array $templateData)
+    {
+        $this->templateData = array_merge($this->templateData, $templateData);
+    }
 
-	/**
-	 * @param array $templateData
-	 */
-	public function setTemplateData(array $templateData) {
-		$this->templateData = $templateData;
-	}
+    /**
+     * @param array $templateData
+     */
+    public function setTemplateData(array $templateData)
+    {
+        $this->templateData = $templateData;
+    }
 
-	/**
-	 * @return \Neos\FluidAdaptor\View\StandaloneView
-	 * @throws MissingArgumentException
-	 */
-	protected function createStandaloneView() {
-		$standaloneView = new \Neos\FluidAdaptor\View\StandaloneView();
-		if (!isset($this->options['templatePathAndFilename'])) {
-			// TODO change Exception
-			throw new MissingArgumentException('The option "templatePathAndFilename" must be set for the AbstractRenderingMessage.', 1327058829);
-		}
-		$standaloneView->setTemplatePathAndFilename($this->options['templatePathAndFilename']);
+    /**
+     * @return \Neos\FluidAdaptor\View\StandaloneView
+     * @throws MissingArgumentException
+     */
+    protected function createStandaloneView()
+    {
+        $standaloneView = new \Neos\FluidAdaptor\View\StandaloneView();
+        if (!isset($this->options['templatePathAndFilename'])) {
+            // TODO change Exception
+            throw new MissingArgumentException('The option "templatePathAndFilename" must be set for the AbstractRenderingMessage.',
+                1327058829);
+        }
+        $standaloneView->setTemplatePathAndFilename($this->options['templatePathAndFilename']);
 
-		if (isset($this->options['partialRootPath'])) {
-			$standaloneView->setPartialRootPath($this->options['partialRootPath']);
-		}
+        if (isset($this->options['partialRootPath'])) {
+            $standaloneView->setPartialRootPath($this->options['partialRootPath']);
+        }
 
-		if (isset($this->options['layoutRootPath'])) {
-			$standaloneView->setLayoutRootPath($this->options['layoutRootPath']);
-		}
+        if (isset($this->options['layoutRootPath'])) {
+            $standaloneView->setLayoutRootPath($this->options['layoutRootPath']);
+        }
 
-		if (isset($this->options['variables'])) {
-			$standaloneView->assignMultiple($this->options['variables']);
-		}
+        if (isset($this->options['variables'])) {
+            $standaloneView->assignMultiple($this->options['variables']);
+        }
 
-		return $standaloneView;
-	}
+        return $standaloneView;
+    }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getRecipientIdentifier() {
-		return $this->recipientIdentifier;
-	}
+    /**
+     * {@inheritdoc}
+     */
+    public function getRecipientIdentifier()
+    {
+        return $this->recipientIdentifier;
+    }
 
-	/**
-	 * @param string $recipientIdentifier
-	 */
-	public function setRecipientIdentifier($recipientIdentifier) {
-		$this->recipientIdentifier = $recipientIdentifier;
-	}
+    /**
+     * @param string $recipientIdentifier
+     */
+    public function setRecipientIdentifier($recipientIdentifier)
+    {
+        $this->recipientIdentifier = $recipientIdentifier;
+    }
 
-	public function getHeaders()
-	{
-		return array();
-	}
+    public function getHeaders()
+    {
+        return array();
+    }
 }

--- a/Classes/Mail/MailHeader.php
+++ b/Classes/Mail/MailHeader.php
@@ -7,40 +7,40 @@ namespace Networkteam\Util\Mail;
 class MailHeader
 {
 
-	/**
-	 * @var string
-	 */
-	protected $name;
+    /**
+     * @var string
+     */
+    protected $name;
 
-	/**
-	 * @var string
-	 */
-	protected $value;
+    /**
+     * @var string
+     */
+    protected $value;
 
-	/**
-	 * MailHeader constructor.
-	 * @param string $name
-	 * @param string $value
-	 */
-	public function __construct(string $name, string $value)
-	{
-		$this->name = $name;
-		$this->value = $value;
-	}
+    /**
+     * MailHeader constructor.
+     * @param string $name
+     * @param string $value
+     */
+    public function __construct(string $name, string $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getName(): string
-	{
-		return $this->name;
-	}
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
 
-	/**
-	 * @return string
-	 */
-	public function getValue(): string
-	{
-		return $this->value;
-	}
+    /**
+     * @return string
+     */
+    public function getValue(): string
+    {
+        return $this->value;
+    }
 }

--- a/Classes/Mail/Mailer.php
+++ b/Classes/Mail/Mailer.php
@@ -17,145 +17,145 @@ use Neos\Flow\Annotations as Flow;
 class Mailer implements MailerInterface
 {
 
-	/**
-	 * @var array
-	 */
-	protected $settings;
+    /**
+     * @var array
+     */
+    protected $settings;
 
-	/**
-	 * @var \Networkteam\Util\Log\MailerLoggerInterface
-	 * @Flow\Inject
-	 */
-	protected $logger;
+    /**
+     * @var \Networkteam\Util\Log\MailerLoggerInterface
+     * @Flow\Inject
+     */
+    protected $logger;
 
-	/**
-	 * @var \Neos\Flow\Log\ThrowableStorageInterface
-	 * @Flow\Inject
-	 */
-	protected $throwableStorage;
+    /**
+     * @var \Neos\Flow\Log\ThrowableStorageInterface
+     * @Flow\Inject
+     */
+    protected $throwableStorage;
 
-	/**
-	 * @var Message
-	 */
-	protected Message $message;
+    /**
+     * @var Message
+     */
+    protected Message $message;
 
-	/**
-	 * Inject the settings
-	 *
-	 * @param array $settings
-	 * @return void
-	 */
-	public function injectSettings(array $settings)
-	{
-		$this->settings = $settings;
-	}
+    /**
+     * Inject the settings
+     *
+     * @param array $settings
+     * @return void
+     */
+    public function injectSettings(array $settings)
+    {
+        $this->settings = $settings;
+    }
 
-	/**
-	 * @param \Networkteam\Util\Mail\MailerMessageInterface $message
-	 * @return \Neos\Error\Messages\Result
-	 */
-	public function send(MailerMessageInterface $message)
-	{
-		$result = new Result();
+    /**
+     * @param \Networkteam\Util\Mail\MailerMessageInterface $message
+     * @return \Neos\Error\Messages\Result
+     */
+    public function send(MailerMessageInterface $message)
+    {
+        $result = new Result();
 
-		$mail = $this->getMessage();
+        $mail = $this->getMessage();
 
-		try {
-			$mail->setFrom($message->getFrom());
-		} catch (\Swift_RfcComplianceException $exception) {
-			$result->forProperty('sender')->addError(new Error($exception->getMessage(), 1365160468));
-		}
+        try {
+            $mail->setFrom($message->getFrom());
+        } catch (\Swift_RfcComplianceException $exception) {
+            $result->forProperty('sender')->addError(new Error($exception->getMessage(), 1365160468));
+        }
 
-		try {
-			$recipientCount = 0;
-			foreach ($message->getRecipient() as $recipient) {
-				if ($recipientCount < 1) {
-					$mail->setTo($recipient);
-				} else {
-					$mail->addCc($recipient);
-				}
-				$recipientCount++;
-			}
-		} catch (\Swift_RfcComplianceException $exception) {
-			$result->forProperty('recipient')->addError(new Error($exception->getMessage(), 1365160498));
-		}
+        try {
+            $recipientCount = 0;
+            foreach ($message->getRecipient() as $recipient) {
+                if ($recipientCount < 1) {
+                    $mail->setTo($recipient);
+                } else {
+                    $mail->addCc($recipient);
+                }
+                $recipientCount++;
+            }
+        } catch (\Swift_RfcComplianceException $exception) {
+            $result->forProperty('recipient')->addError(new Error($exception->getMessage(), 1365160498));
+        }
 
-		if ((string)$message->getSubject() === '') {
-			$result->forProperty('subject')->addError(new Error('Missing subject for mail', 1365172209));
-		}
+        if ((string)$message->getSubject() === '') {
+            $result->forProperty('subject')->addError(new Error('Missing subject for mail', 1365172209));
+        }
 
-		$mail->setSubject($message->getSubject());
+        $mail->setSubject($message->getSubject());
 
-		$mail->setBody($message->getBody(), $message->getFormat());
+        $mail->setBody($message->getBody(), $message->getFormat());
 
-		if ($message->getReplyTo()) {
-			$mail->setReplyTo($message->getReplyTo());
-		}
+        if ($message->getReplyTo()) {
+            $mail->setReplyTo($message->getReplyTo());
+        }
 
-		foreach ($message->getHeaders() as $header) {
-			$mail->getHeaders()->addTextHeader($header->getName(), $header->getValue());
-		}
+        foreach ($message->getHeaders() as $header) {
+            $mail->getHeaders()->addTextHeader($header->getName(), $header->getValue());
+        }
 
-		if ($result->hasErrors()) {
-			$logMessage = 'Failed sending mail to "' . implode('", "',
-					array_keys((array)$mail->getTo())) . '" (' . $message->getRecipientIdentifier() . ') with subject "' . $mail->getSubject() . '"';
-			$flattenedErrors = $result->getFlattenedErrors();
-			if ($flattenedErrors !== []) {
-				$additionalData = [];
-				foreach ($flattenedErrors as $propertyPath => $error) {
-					$additionalData[$propertyPath] = $error;
-				}
-			} else {
-				$additionalData = null;
-			}
-			$this->logger->error($logMessage, $additionalData);
-		} else {
-			if (isset($this->settings['Mailer']['bcc'])) {
-				foreach ($this->settings['Mailer']['bcc'] as $bccMail) {
-					$mail->addBcc($bccMail);
-				}
-			}
+        if ($result->hasErrors()) {
+            $logMessage = 'Failed sending mail to "' . implode('", "',
+                    array_keys((array)$mail->getTo())) . '" (' . $message->getRecipientIdentifier() . ') with subject "' . $mail->getSubject() . '"';
+            $flattenedErrors = $result->getFlattenedErrors();
+            if ($flattenedErrors !== []) {
+                $additionalData = [];
+                foreach ($flattenedErrors as $propertyPath => $error) {
+                    $additionalData[$propertyPath] = $error;
+                }
+            } else {
+                $additionalData = null;
+            }
+            $this->logger->error($logMessage, $additionalData);
+        } else {
+            if (isset($this->settings['Mailer']['bcc'])) {
+                foreach ($this->settings['Mailer']['bcc'] as $bccMail) {
+                    $mail->addBcc($bccMail);
+                }
+            }
 
-			if (isset($this->settings['Mailer']['overrideRecipients'])) {
-				$mail->setBcc([]);
-				$mail->setCc([]);
-				$mail->setTo($this->settings['Mailer']['overrideRecipients']);
-			}
+            if (isset($this->settings['Mailer']['overrideRecipients'])) {
+                $mail->setBcc([]);
+                $mail->setCc([]);
+                $mail->setTo($this->settings['Mailer']['overrideRecipients']);
+            }
 
-			try {
-				$recipients = $mail->send();
-				if ($recipients === 0) {
-					$result->addError(new Error('No recipients accepted', 1376582260));
-					$logMessage = 'No Recipients accepted: ' . implode(',', $mail->getFailedRecipients());
-				} else {
-					$logMessage = 'Sent mail to: ' . implode(',',
-							array_keys($mail->getTo())) . ' with subject: ' . $mail->getSubject();
-				}
-				$this->logger->info($logMessage);
-			} catch (\Exception $e) {
-				$message = $this->throwableStorage->logThrowable($e);
-				$this->logger->error('Failed sending mail: ' . $message);
+            try {
+                $recipients = $mail->send();
+                if ($recipients === 0) {
+                    $result->addError(new Error('No recipients accepted', 1376582260));
+                    $logMessage = 'No Recipients accepted: ' . implode(',', $mail->getFailedRecipients());
+                } else {
+                    $logMessage = 'Sent mail to: ' . implode(',',
+                            array_keys($mail->getTo())) . ' with subject: ' . $mail->getSubject();
+                }
+                $this->logger->info($logMessage);
+            } catch (\Exception $e) {
+                $message = $this->throwableStorage->logThrowable($e);
+                $this->logger->error('Failed sending mail: ' . $message);
 
-				$result->addError(new Error('Error sending email', 1438095110));
-			}
-		}
+                $result->addError(new Error('Error sending email', 1438095110));
+            }
+        }
 
-		return $result;
-	}
+        return $result;
+    }
 
-	/**
-	 * @param Message $message
-	 */
-	public function setMessage(Message $message)
-	{
-		$this->message = $message;
-	}
+    /**
+     * @param Message $message
+     */
+    public function setMessage(Message $message)
+    {
+        $this->message = $message;
+    }
 
-	/**
-	 * @return Message
-	 */
-	protected function getMessage()
-	{
-		return $this->message;
-	}
+    /**
+     * @return Message
+     */
+    protected function getMessage()
+    {
+        return $this->message;
+    }
 }

--- a/Classes/Mail/MailerInterface.php
+++ b/Classes/Mail/MailerInterface.php
@@ -10,12 +10,13 @@ use Neos\Error\Messages\Result;
 /**
  * Mailer interface
  */
-interface MailerInterface {
+interface MailerInterface
+{
 
-	/**
-	 * @param \Networkteam\Util\Mail\MailerMessageInterface $message
-	 * @return \Neos\Error\Messages\Result
-	 */
-	public function send(MailerMessageInterface $message);
+    /**
+     * @param \Networkteam\Util\Mail\MailerMessageInterface $message
+     * @return \Neos\Error\Messages\Result
+     */
+    public function send(MailerMessageInterface $message);
 
 }

--- a/Classes/Mail/MailerMessageInterface.php
+++ b/Classes/Mail/MailerMessageInterface.php
@@ -4,50 +4,50 @@ namespace Networkteam\Util\Mail;
 /***************************************************************
  *  (c) 2013 networkteam GmbH - all rights reserved
  ***************************************************************/
+interface MailerMessageInterface
+{
 
-interface MailerMessageInterface {
+    /**
+     * Returns the mimetype of the message(text/html)
+     *
+     * @return string
+     */
+    public function getFormat();
 
-	/**
-	 * Returns the mimetype of the message(text/html)
-	 *
-	 * @return string
-	 */
-	public function getFormat();
+    /**
+     * Returns the message body, can be either HTML or text
+     *
+     * @return string
+     */
+    public function getBody();
 
-	/**
-	 * Returns the message body, can be either HTML or text
-	 *
-	 * @return string
-	 */
-	public function getBody();
+    /**
+     * @return mixed
+     */
+    public function getFrom();
 
-	/**
-	 * @return mixed
-	 */
-	public function getFrom();
+    /**
+     * @return string
+     */
+    public function getReplyTo();
 
-	/**
-	 * @return string
-	 */
-	public function getReplyTo();
+    /**
+     * @return array An array of recipient addresses (string or array)
+     */
+    public function getRecipient();
 
-	/**
-	 * @return array An array of recipient addresses (string or array)
-	 */
-	public function getRecipient();
+    /**
+     * @return string
+     */
+    public function getSubject();
 
-	/**
-	 * @return string
-	 */
-	public function getSubject();
+    /**
+     * @return string A recipient identifier (not necessarily an email address) for logging
+     */
+    public function getRecipientIdentifier();
 
-	/**
-	 * @return string A recipient identifier (not necessarily an email address) for logging
-	 */
-	public function getRecipientIdentifier();
-
-	/**
-	 * @return array<MailHeader>
-	 */
-	public function getHeaders();
+    /**
+     * @return array<MailHeader>
+     */
+    public function getHeaders();
 }

--- a/Classes/Mail/MissingArgumentException.php
+++ b/Classes/Mail/MissingArgumentException.php
@@ -4,7 +4,7 @@ namespace Networkteam\Util\Mail;
 /***************************************************************
  *  (c) 2013 networkteam GmbH - all rights reserved
  ***************************************************************/
-
-class MissingArgumentException extends \Networkteam\Util\Exception {
+class MissingArgumentException extends \Networkteam\Util\Exception
+{
 
 }

--- a/Classes/Persistence/MysqlSequenceGenerator.php
+++ b/Classes/Persistence/MysqlSequenceGenerator.php
@@ -8,19 +8,20 @@ namespace Networkteam\Util\Persistence;
 use Doctrine\ORM\EntityManager;
 use Neos\Flow\Annotations as Flow;
 
-class MysqlSequenceGenerator implements SequenceGeneratorInterface {
+class MysqlSequenceGenerator implements SequenceGeneratorInterface
+{
 
-	/**
-	 * @var \Doctrine\ORM\EntityManagerInterface
-	 * @Flow\Inject
-	 */
-	protected $entityManager;
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     * @Flow\Inject
+     */
+    protected $entityManager;
 
-	public function next($sequenceName): int
+    public function next($sequenceName): int
     {
-		/* @var $connection \Doctrine\DBAL\Connection */
-		$connection = $this->entityManager->getConnection();
-		$connection->insert('networkteam_sequence', array('sequencename' => $sequenceName), array('string'));
-		return $connection->lastInsertId();
-	}
+        /* @var $connection \Doctrine\DBAL\Connection */
+        $connection = $this->entityManager->getConnection();
+        $connection->insert('networkteam_sequence', array('sequencename' => $sequenceName), array('string'));
+        return $connection->lastInsertId();
+    }
 }

--- a/Classes/Persistence/SequenceGeneratorInterface.php
+++ b/Classes/Persistence/SequenceGeneratorInterface.php
@@ -4,9 +4,9 @@ namespace Networkteam\Util\Persistence;
 /***************************************************************
  *  (c) 2013 networkteam GmbH - all rights reserved
  ***************************************************************/
+interface SequenceGeneratorInterface
+{
 
-interface SequenceGeneratorInterface {
-
-	public function next($sequenceName): int;
+    public function next($sequenceName): int;
 
 }

--- a/Classes/Property/TypeConverter/DeepArrayConverter.php
+++ b/Classes/Property/TypeConverter/DeepArrayConverter.php
@@ -45,8 +45,7 @@ class DeepArrayConverter extends AbstractTypeConverter
         $targetType,
         array $convertedChildProperties = array(),
         PropertyMappingConfigurationInterface $configuration = null
-    ): array
-    {
+    ): array {
         return $convertedChildProperties;
     }
 
@@ -73,8 +72,7 @@ class DeepArrayConverter extends AbstractTypeConverter
         $targetType,
         $propertyName,
         PropertyMappingConfigurationInterface $configuration
-    ): string
-    {
+    ): string {
         $parsedTargetType = \Neos\Utility\TypeHandling::parseType($targetType);
         return $parsedTargetType['elementType'];
     }

--- a/Classes/Resource/ResourceLocator.php
+++ b/Classes/Resource/ResourceLocator.php
@@ -37,8 +37,7 @@ class ResourceLocator
         PersistentResource $resource = null,
         bool $localize = true,
         bool $appendCacheBuster = true
-    ): string
-    {
+    ): string {
         $cacheBuster = '';
 
         if ($resource !== null) {

--- a/Classes/Serializer/JsonSerializer.php
+++ b/Classes/Serializer/JsonSerializer.php
@@ -29,7 +29,7 @@ class JsonSerializer
      * @param array $configuration Configuration for transforming the value
      * @return array The transformed value
      */
-    protected function transformValue(mixed $value, array $configuration) : array
+    protected function transformValue(mixed $value, array $configuration): array
     {
         if (is_array($value) || $value instanceof \ArrayAccess) {
             $array = array();

--- a/Classes/Serializer/JsonSerializerInterface.php
+++ b/Classes/Serializer/JsonSerializerInterface.php
@@ -7,6 +7,7 @@ namespace Networkteam\Util\Serializer;
 
 use Symfony\Component\Serializer\SerializerInterface;
 
-interface JsonSerializerInterface extends SerializerInterface {
+interface JsonSerializerInterface extends SerializerInterface
+{
 
 }

--- a/Classes/Translation/XliffFileDumper.php
+++ b/Classes/Translation/XliffFileDumper.php
@@ -12,59 +12,59 @@ use Symfony\Component\Translation\MessageCatalogue;
 class XliffFileDumper extends FileDumper
 {
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public function formatCatalogue(MessageCatalogue $messages, $domain, array $options = array())
-	{
-		$dom = new \DOMDocument('1.0', 'utf-8');
-		$dom->formatOutput = TRUE;
+    /**
+     * {@inheritDoc}
+     */
+    public function formatCatalogue(MessageCatalogue $messages, $domain, array $options = array())
+    {
+        $dom = new \DOMDocument('1.0', 'utf-8');
+        $dom->formatOutput = true;
 
-		$xliff = $dom->createElement('xliff');
-		$xliff = $dom->appendChild($xliff);
+        $xliff = $dom->createElement('xliff');
+        $xliff = $dom->appendChild($xliff);
 
-		$xliff->setAttribute('version', '1.2');
-		$xliff->setAttribute('xmlns', 'urn:oasis:names:tc:xliff:document:1.2');
+        $xliff->setAttribute('version', '1.2');
+        $xliff->setAttribute('xmlns', 'urn:oasis:names:tc:xliff:document:1.2');
 
-		$xliffFile = $xliff->appendChild($dom->createElement('file'));
-		$xliffFile->setAttribute('source-language', $messages->getLocale());
-		$xliffFile->setAttribute('datatype', 'plaintext');
-		$xliffFile->setAttribute('original', 'file.ext');
+        $xliffFile = $xliff->appendChild($dom->createElement('file'));
+        $xliffFile->setAttribute('source-language', $messages->getLocale());
+        $xliffFile->setAttribute('datatype', 'plaintext');
+        $xliffFile->setAttribute('original', 'file.ext');
 
-		$xliffBody = $xliffFile->appendChild($dom->createElement('body'));
-		foreach ($messages->all($domain) as $source => $target) {
-			$translation = $dom->createElement('trans-unit');
+        $xliffBody = $xliffFile->appendChild($dom->createElement('body'));
+        foreach ($messages->all($domain) as $source => $target) {
+            $translation = $dom->createElement('trans-unit');
 
-			$translation->setAttribute('id', $source);
-			$translation->setAttribute('resname', $source);
+            $translation->setAttribute('id', $source);
+            $translation->setAttribute('resname', $source);
 
-			$s = $translation->appendChild($dom->createElement('source'));
-			$s->appendChild($dom->createTextNode($target));
+            $s = $translation->appendChild($dom->createElement('source'));
+            $s->appendChild($dom->createTextNode($target));
 
-			$t = $translation->appendChild($dom->createElement('target'));
-			$t->appendChild($dom->createTextNode($target));
+            $t = $translation->appendChild($dom->createElement('target'));
+            $t->appendChild($dom->createTextNode($target));
 
-			$xliffBody->appendChild($translation);
-		}
+            $xliffBody->appendChild($translation);
+        }
 
-		$xmlString = $dom->saveXML();
-		// Replace whitespaces with tabs
-		return str_replace('  ', "\t", $xmlString);
-	}
+        $xmlString = $dom->saveXML();
+        // Replace whitespaces with tabs
+        return str_replace('  ', "\t", $xmlString);
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	protected function format(MessageCatalogue $messages, $domain)
-	{
-		return $this->formatCatalogue($messages, $domain);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    protected function format(MessageCatalogue $messages, $domain)
+    {
+        return $this->formatCatalogue($messages, $domain);
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	protected function getExtension()
-	{
-		return 'xlf';
-	}
+    /**
+     * {@inheritDoc}
+     */
+    protected function getExtension()
+    {
+        return 'xlf';
+    }
 }

--- a/Classes/Translation/XliffFileUpdater.php
+++ b/Classes/Translation/XliffFileUpdater.php
@@ -8,63 +8,67 @@ namespace Networkteam\Util\Translation;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Package\FlowPackageInterface;
 
-class XliffFileUpdater {
+class XliffFileUpdater
+{
 
-	/**
-	 * @var \Symfony\Component\Translation\Loader\XliffFileLoader
-	 */
-	protected $xliffFileLoader;
+    /**
+     * @var \Symfony\Component\Translation\Loader\XliffFileLoader
+     */
+    protected $xliffFileLoader;
 
-	/**
-	 * @var \Networkteam\Util\Translation\XliffFileDumper
-	 * @Flow\Inject
-	 */
-	protected $xliffFileDumper;
+    /**
+     * @var \Networkteam\Util\Translation\XliffFileDumper
+     * @Flow\Inject
+     */
+    protected $xliffFileDumper;
 
-	/**
-	 * @var \Neos\Flow\Package\PackageManager
-	 * @Flow\Inject
-	 */
-	protected $packageManager;
+    /**
+     * @var \Neos\Flow\Package\PackageManager
+     * @Flow\Inject
+     */
+    protected $packageManager;
 
-	public function initializeObject() {
-		$this->xliffFileLoader = new \Symfony\Component\Translation\Loader\XliffFileLoader();
-	}
+    public function initializeObject()
+    {
+        $this->xliffFileLoader = new \Symfony\Component\Translation\Loader\XliffFileLoader();
+    }
 
-	/**
-	 * @param string $packageKey
-	 * @param string $locale
-	 * @param string $catalogue
-	 */
-	public function updateCatalogue($translationUpdates, $packageKey, $locale, $catalogue = 'Main') {
-		$resource = $this->getTranslationResourcePath($packageKey, $locale, $catalogue);
-		$existingCatalogue = $this->xliffFileLoader->load($resource, $locale);
-		foreach ($translationUpdates as $translation) {
-			if (!$existingCatalogue->has($translation['id'])) {
-				$existingCatalogue->set($translation['id'], $translation['text']);
-			}
-		}
+    /**
+     * @param string $packageKey
+     * @param string $locale
+     * @param string $catalogue
+     */
+    public function updateCatalogue($translationUpdates, $packageKey, $locale, $catalogue = 'Main')
+    {
+        $resource = $this->getTranslationResourcePath($packageKey, $locale, $catalogue);
+        $existingCatalogue = $this->xliffFileLoader->load($resource, $locale);
+        foreach ($translationUpdates as $translation) {
+            if (!$existingCatalogue->has($translation['id'])) {
+                $existingCatalogue->set($translation['id'], $translation['text']);
+            }
+        }
 
-		$this->xliffFileDumper->dump($existingCatalogue, array('path' => '/tmp/'));
-		copy('/tmp/' . 'messages.' . $locale . '.xlf', $resource);
-	}
+        $this->xliffFileDumper->dump($existingCatalogue, array('path' => '/tmp/'));
+        copy('/tmp/' . 'messages.' . $locale . '.xlf', $resource);
+    }
 
-	/**
-	 * @param $packageKey
-	 * @param $locale
-	 * @param $catalogue
-	 *
-	 * @return ?string
-	 */
-	protected function getTranslationResourcePath($packageKey, $locale, $catalogue) {
-		$package = $this->packageManager->getPackage($packageKey);
+    /**
+     * @param $packageKey
+     * @param $locale
+     * @param $catalogue
+     *
+     * @return ?string
+     */
+    protected function getTranslationResourcePath($packageKey, $locale, $catalogue)
+    {
+        $package = $this->packageManager->getPackage($packageKey);
 
-		if (!$package instanceof FlowPackageInterface) {
-			return null;
-		}
+        if (!$package instanceof FlowPackageInterface) {
+            return null;
+        }
 
-		$resourcesPath = $package->getResourcesPath();
-		$translationResource = $resourcesPath . 'Private/Translations/' . $locale . '/' . $catalogue . '.xlf';
-		return $translationResource;
-	}
+        $resourcesPath = $package->getResourcesPath();
+        $translationResource = $resourcesPath . 'Private/Translations/' . $locale . '/' . $catalogue . '.xlf';
+        return $translationResource;
+    }
 }

--- a/Classes/Validation/Validator/PasswordValidator.php
+++ b/Classes/Validation/Validator/PasswordValidator.php
@@ -8,43 +8,50 @@ namespace Networkteam\Util\Validation\Validator;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Validation\Validator\AbstractValidator;
 
-class PasswordValidator extends AbstractValidator {
+class PasswordValidator extends AbstractValidator
+{
 
-	protected $supportedOptions = array(
-		'allowEmpty' => array(FALSE, 'If set the validation will not fail if the value is empty, used for updating records when not setting a new password', FALSE),
-		'minimumLength' => array(8, 'Minumum length of password', FALSE)
-	);
+    protected $supportedOptions = array(
+        'allowEmpty' => array(
+            false,
+            'If set the validation will not fail if the value is empty, used for updating records when not setting a new password',
+            false
+        ),
+        'minimumLength' => array(8, 'Minumum length of password', false)
+    );
 
-	/**
-	 * Check if $value is valid. If it is not valid, needs to add an error
-	 * to Result.
-	 *
-	 * passwords should be provided as array
-	 *
-	 * @param mixed $value
-	 * @return void
-	 */
-	protected function isValid($value) {
-		if (!is_array($value) || count($value) < 2) {
-			$this->addError('The given value was not an array of passwords.', 1372340267);
-			return;
-		}
+    /**
+     * Check if $value is valid. If it is not valid, needs to add an error
+     * to Result.
+     *
+     * passwords should be provided as array
+     *
+     * @param mixed $value
+     * @return void
+     */
+    protected function isValid($value)
+    {
+        if (!is_array($value) || count($value) < 2) {
+            $this->addError('The given value was not an array of passwords.', 1372340267);
+            return;
+        }
 
-		// get the option for the validation
-		$minimumLength = $this->options['minimumLength'];
+        // get the option for the validation
+        $minimumLength = $this->options['minimumLength'];
 
-		// check for empty password
-		if ($value[0] === '' && !$this->options['allowEmpty']) {
-			$this->addError('The password is to weak.', 1221560717);
-		}
-		// check for password length
-		if (strlen($value[0]) < $minimumLength && !$this->options['allowEmpty']) {
-			$this->addError('The password is to short, minimum length is ' . $minimumLength, 1221560719, array($minimumLength));
-		}
+        // check for empty password
+        if ($value[0] === '' && !$this->options['allowEmpty']) {
+            $this->addError('The password is to weak.', 1221560717);
+        }
+        // check for password length
+        if (strlen($value[0]) < $minimumLength && !$this->options['allowEmpty']) {
+            $this->addError('The password is to short, minimum length is ' . $minimumLength, 1221560719,
+                array($minimumLength));
+        }
 
-		// check that the passwords are the same
-		if (strcmp($value[0], $value[1]) != 0) {
-			$this->addError('The password do not match!', 1372861059);
-		}
-	}
+        // check that the passwords are the same
+        if (strcmp($value[0], $value[1]) != 0) {
+            $this->addError('The password do not match!', 1372861059);
+        }
+    }
 }

--- a/Classes/Validation/Validator/RangeValidator.php
+++ b/Classes/Validation/Validator/RangeValidator.php
@@ -10,28 +10,30 @@ use Neos\Flow\Validation\Validator\AbstractValidator;
 /**
  * A number range validator
  */
-class RangeValidator extends AbstractValidator {
+class RangeValidator extends AbstractValidator
+{
 
-	/**
-	 * @var array
-	 */
-	protected $supportedOptions = array(
-		'minimum' => array(0, 'The minimum number to accept', 'integer'),
-		'maximum' => array(PHP_INT_MAX, 'The maximum number to accept', 'integer')
-	);
+    /**
+     * @var array
+     */
+    protected $supportedOptions = array(
+        'minimum' => array(0, 'The minimum number to accept', 'integer'),
+        'maximum' => array(PHP_INT_MAX, 'The maximum number to accept', 'integer')
+    );
 
-	/**
-	 * Check if $value is valid. If it is not valid, needs to add an error
-	 * to Result.
-	 *
-	 * @param mixed $value
-	 * @return void
-	 */
-	protected function isValid($value) {
-		$minimum = intval($this->options['minimum']);
-		$maximum = intval($this->options['maximum']);
-		if ((int)$value < $minimum || (int)$value > $maximum) {
-			$this->addError('The value must be between %1$d and %2$d.', 1365773104, array($minimum, $maximum));
-		}
-	}
+    /**
+     * Check if $value is valid. If it is not valid, needs to add an error
+     * to Result.
+     *
+     * @param mixed $value
+     * @return void
+     */
+    protected function isValid($value)
+    {
+        $minimum = intval($this->options['minimum']);
+        $maximum = intval($this->options['maximum']);
+        if ((int)$value < $minimum || (int)$value > $maximum) {
+            $this->addError('The value must be between %1$d and %2$d.', 1365773104, array($minimum, $maximum));
+        }
+    }
 }

--- a/Classes/ViewHelpers/Form/HasValidationResultsViewHelper.php
+++ b/Classes/ViewHelpers/Form/HasValidationResultsViewHelper.php
@@ -13,43 +13,44 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 class HasValidationResultsViewHelper extends AbstractConditionViewHelper
 {
 
-	public function initializeArguments()
-	{
-		$this->registerArgument('then', 'mixed', 'Value to be returned if the condition if met.', false);
-		$this->registerArgument('else', 'mixed', 'Value to be returned if the condition if not met.', false);
-		$this->registerArgument('for', 'string', 'The name of the error name (e.g. argument name or property name). This can also be a property path (like blog.title), and will then only display the validation errors of that property.', false, null);
-	}
+    public function initializeArguments()
+    {
+        $this->registerArgument('then', 'mixed', 'Value to be returned if the condition if met.', false);
+        $this->registerArgument('else', 'mixed', 'Value to be returned if the condition if not met.', false);
+        $this->registerArgument('for', 'string',
+            'The name of the error name (e.g. argument name or property name). This can also be a property path (like blog.title), and will then only display the validation errors of that property.',
+            false, null);
+    }
 
-	public function render()
-	{
-		if (static::evaluateCondition($this->arguments, $this->renderingContext)) {
-			return $this->renderThenChild();
-		}
+    public function render()
+    {
+        if (static::evaluateCondition($this->arguments, $this->renderingContext)) {
+            return $this->renderThenChild();
+        }
 
-		return $this->renderElseChild();
-	}
+        return $this->renderElseChild();
+    }
 
-	protected static function evaluateCondition(
-		$arguments,
-		RenderingContextInterface $renderingContext
-	)
-	{
+    protected static function evaluateCondition(
+        $arguments,
+        RenderingContextInterface $renderingContext
+    ) {
 
-		if (!$renderingContext instanceof RenderingContext) {
-			return false;
-		}
+        if (!$renderingContext instanceof RenderingContext) {
+            return false;
+        }
 
-		$controllerContext = $renderingContext->getControllerContext();
+        $controllerContext = $renderingContext->getControllerContext();
 
-		/** @var Result $validationResults */
-		$validationResults = $controllerContext->getRequest()->getInternalArgument('__submittedArgumentValidationResults');
+        /** @var Result $validationResults */
+        $validationResults = $controllerContext->getRequest()->getInternalArgument('__submittedArgumentValidationResults');
 
-		$forProperty = $arguments['for'] ?? null;
+        $forProperty = $arguments['for'] ?? null;
 
-		if ($validationResults !== null && $forProperty !== null) {
-			$validationResults = $validationResults->forProperty($forProperty);
-		}
+        if ($validationResults !== null && $forProperty !== null) {
+            $validationResults = $validationResults->forProperty($forProperty);
+        }
 
-		return $validationResults !== null && $validationResults->hasErrors();
-	}
+        return $validationResults !== null && $validationResults->hasErrors();
+    }
 }

--- a/Classes/ViewHelpers/Form/TranslatedOptionsViewHelper.php
+++ b/Classes/ViewHelpers/Form/TranslatedOptionsViewHelper.php
@@ -28,9 +28,12 @@ class TranslatedOptionsViewHelper extends \Neos\FluidAdaptor\Core\ViewHelper\Abs
     {
         parent::initializeArguments();
         $this->registerArgument('prefix', 'string', 'Prefix for translation ids (e.g. "options.foo")');
-        $this->registerArgument('translateById', 'boolean', 'Use translateById or translateByOriginalLabel', false, true);
+        $this->registerArgument('translateById', 'boolean', 'Use translateById or translateByOriginalLabel', false,
+            true);
         $this->registerArgument('package', 'string', 'Key of the package containing the source file');
-        $this->registerArgument('sourceName', 'string', 'Name of file with translations, base path is $packageKey/Resources/Private/Locale/Translations/', false, 'Main');
+        $this->registerArgument('sourceName', 'string',
+            'Name of file with translations, base path is $packageKey/Resources/Private/Locale/Translations/', false,
+            'Main');
         $this->registerArgument('locale', 'string', 'A valid locale identifier according to UTS#35');
     }
 

--- a/Classes/ViewHelpers/Security/IfAccessViewHelper.php
+++ b/Classes/ViewHelpers/Security/IfAccessViewHelper.php
@@ -12,19 +12,21 @@ use \TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 class IfAccessViewHelper extends \Neos\FluidAdaptor\ViewHelpers\Security\IfAccessViewHelper
 {
 
-	const PRIVILEGE_TARGET_SEPARATOR = '|';
+    const PRIVILEGE_TARGET_SEPARATOR = '|';
 
-	const CONDITION_MODE_AND = 'and';
+    const CONDITION_MODE_AND = 'and';
 
-	const CONDITION_MODE_OR = 'or';
+    const CONDITION_MODE_OR = 'or';
 
-	public function initializeArguments()
-	{
-		parent::initializeArguments();
-		$description = sprintf('One or more privilege target identifier (separated by "%s")', self::PRIVILEGE_TARGET_SEPARATOR);
-		$this->overrideArgument('privilegeTarget', 'string', $description, true);
-		$this->registerArgument('mode', 'string', 'Condition mode for multiple privelege targets', false, self::CONDITION_MODE_OR);
-	}
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $description = sprintf('One or more privilege target identifier (separated by "%s")',
+            self::PRIVILEGE_TARGET_SEPARATOR);
+        $this->overrideArgument('privilegeTarget', 'string', $description, true);
+        $this->registerArgument('mode', 'string', 'Condition mode for multiple privelege targets', false,
+            self::CONDITION_MODE_OR);
+    }
 
     /**
      * The condition evaluates to true if one of the privilege targets is granted
@@ -35,25 +37,26 @@ class IfAccessViewHelper extends \Neos\FluidAdaptor\ViewHelpers\Security\IfAcces
      */
     protected static function evaluateCondition($arguments, RenderingContextInterface $renderingContext)
     {
-		if (!$renderingContext instanceof \Neos\FluidAdaptor\Core\Rendering\RenderingContext) {
-			return false;
-		}
+        if (!$renderingContext instanceof \Neos\FluidAdaptor\Core\Rendering\RenderingContext) {
+            return false;
+        }
         $privilegeManager = static::getPrivilegeManager($renderingContext);
         $privilegeTargets = explode(self::PRIVILEGE_TARGET_SEPARATOR, $arguments['privilegeTarget']);
 
-		$privilegeTargetGrantedCount = 0;
-		foreach ($privilegeTargets as $privilegeTarget) {
-			$isPrivilegeTargetGranted = $privilegeManager->isPrivilegeTargetGranted($privilegeTarget, $arguments['parameters']);
+        $privilegeTargetGrantedCount = 0;
+        foreach ($privilegeTargets as $privilegeTarget) {
+            $isPrivilegeTargetGranted = $privilegeManager->isPrivilegeTargetGranted($privilegeTarget,
+                $arguments['parameters']);
 
-			if ($isPrivilegeTargetGranted) {
-				$privilegeTargetGrantedCount++;
-			}
-		}
+            if ($isPrivilegeTargetGranted) {
+                $privilegeTargetGrantedCount++;
+            }
+        }
 
-		if (isset($arguments['mode']) && $arguments['mode'] === self::CONDITION_MODE_AND) {
-			return $privilegeTargetGrantedCount === count($privilegeTargets);
-		} else {
-			return $privilegeTargetGrantedCount > 0;
-		}
-	}
+        if (isset($arguments['mode']) && $arguments['mode'] === self::CONDITION_MODE_AND) {
+            return $privilegeTargetGrantedCount === count($privilegeTargets);
+        } else {
+            return $privilegeTargetGrantedCount > 0;
+        }
+    }
 }

--- a/Classes/ViewHelpers/Widget/PaginateViewHelper.php
+++ b/Classes/ViewHelpers/Widget/PaginateViewHelper.php
@@ -47,11 +47,12 @@ class PaginateViewHelper extends \Neos\FluidAdaptor\Core\Widget\AbstractWidgetVi
         parent::initializeArguments();
         $this->registerArgument('objects', QueryResultInterface::class, 'Objects', true);
         $this->registerArgument('as', 'string', 'as', true);
-        $this->registerArgument('configuration', 'array', 'Widget configuration', false, ['itemsPerPage' => 10, 'insertAbove' => false, 'insertBelow' => true, 'maximumNumberOfLinks' => 99]);
+        $this->registerArgument('configuration', 'array', 'Widget configuration', false,
+            ['itemsPerPage' => 10, 'insertAbove' => false, 'insertBelow' => true, 'maximumNumberOfLinks' => 99]);
     }
 
     public function render(): string
     {
-        return  $this->initiateSubRequest();
+        return $this->initiateSubRequest();
     }
 }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,6 +1,5 @@
 Networkteam:
   Util:
-    serviceContext: 'neos-flow'
     OpenExchangeRateConverter:
       appId: 'b05f50cd27864a519887e3141c64cb34'
       baseUrl: 'http://openexchangerates.org/api/'

--- a/Resources/Private/Templates/ViewHelpers/Widget/Paginate/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Widget/Paginate/Index.html
@@ -1,72 +1,72 @@
 <f:if condition="{configuration.insertAbove}">
-	<f:render section="paginator" arguments="{pagination: pagination}" />
+    <f:render section="paginator" arguments="{pagination: pagination}"/>
 </f:if>
 
-<f:renderChildren arguments="{contentArguments}" />
+<f:renderChildren arguments="{contentArguments}"/>
 
 <f:if condition="{configuration.insertBelow}">
-	<f:render section="paginator" arguments="{pagination: pagination}" />
+    <f:render section="paginator" arguments="{pagination: pagination}"/>
 </f:if>
 
 <f:section name="paginator">
-	<f:if condition="{pagination.numberOfPages} > 1">
-		<div class="pagination">
-			<ul class="typo3-widget-paginator">
-				<f:if condition="{pagination.previousPage}">
-					<li class="previous">
-						<f:if condition="{pagination.previousPage} > 1">
-							<f:then>
-								<f:widget.link action="index" arguments="{currentPage: pagination.previousPage}">previous</f:widget.link>
-							</f:then>
-							<f:else>
-								<f:widget.link action="index">previous</f:widget.link>
-							</f:else>
-						</f:if>
-					</li>
-				</f:if>
-				<f:if condition="{pagination.displayRangeStart} > 1">
-					<li class="first">
-						<f:widget.link action="index">1</f:widget.link>
-					</li>
-				</f:if>
-				<f:if condition="{pagination.hasLessPages}">
-					<li><a href="#">...</a></li>
-				</f:if>
-				<f:for each="{pagination.pages}" as="page">
-					<f:if condition="{page.isCurrent}">
-						<f:then>
-							<li class="active">
-								<a href="#">{page.number}</a>
-							</li>
-						</f:then>
-						<f:else>
-							<li>
-								<f:if condition="{page.number} > 1">
-									<f:then>
-										<f:widget.link action="index" arguments="{currentPage: page.number}">{page.number}</f:widget.link>
-									</f:then>
-									<f:else>
-										<f:widget.link action="index">{page.number}</f:widget.link>
-									</f:else>
-								</f:if>
-							</li>
-						</f:else>
-					</f:if>
-				</f:for>
-				<f:if condition="{pagination.hasMorePages}">
-					<li><a href="#">...</a></li>
-				</f:if>
-				<f:if condition="{pagination.displayRangeEnd} < {pagination.numberOfPages}">
-					<li class="last">
-						<f:widget.link action="index" arguments="{currentPage: pagination.numberOfPages}">{pagination.numberOfPages}</f:widget.link>
-					</li>
-				</f:if>
-				<f:if condition="{pagination.nextPage}">
-					<li class="next">
-						<f:widget.link action="index" arguments="{currentPage: pagination.nextPage}">next</f:widget.link>
-					</li>
-				</f:if>
-			</ul>
-		</div>
-	</f:if>
+    <f:if condition="{pagination.numberOfPages} > 1">
+        <div class="pagination">
+            <ul class="typo3-widget-paginator">
+                <f:if condition="{pagination.previousPage}">
+                    <li class="previous">
+                        <f:if condition="{pagination.previousPage} > 1">
+                            <f:then>
+                                <f:widget.link action="index" arguments="{currentPage: pagination.previousPage}">previous</f:widget.link>
+                            </f:then>
+                            <f:else>
+                                <f:widget.link action="index">previous</f:widget.link>
+                            </f:else>
+                        </f:if>
+                    </li>
+                </f:if>
+                <f:if condition="{pagination.displayRangeStart} > 1">
+                    <li class="first">
+                        <f:widget.link action="index">1</f:widget.link>
+                    </li>
+                </f:if>
+                <f:if condition="{pagination.hasLessPages}">
+                    <li><a href="#">...</a></li>
+                </f:if>
+                <f:for each="{pagination.pages}" as="page">
+                    <f:if condition="{page.isCurrent}">
+                        <f:then>
+                            <li class="active">
+                                <a href="#">{page.number}</a>
+                            </li>
+                        </f:then>
+                        <f:else>
+                            <li>
+                                <f:if condition="{page.number} > 1">
+                                    <f:then>
+                                        <f:widget.link action="index" arguments="{currentPage: page.number}">{page.number}</f:widget.link>
+                                    </f:then>
+                                    <f:else>
+                                        <f:widget.link action="index">{page.number}</f:widget.link>
+                                    </f:else>
+                                </f:if>
+                            </li>
+                        </f:else>
+                    </f:if>
+                </f:for>
+                <f:if condition="{pagination.hasMorePages}">
+                    <li><a href="#">...</a></li>
+                </f:if>
+                <f:if condition="{pagination.displayRangeEnd} < {pagination.numberOfPages}">
+                    <li class="last">
+                        <f:widget.link action="index" arguments="{currentPage: pagination.numberOfPages}">{pagination.numberOfPages}</f:widget.link>
+                    </li>
+                </f:if>
+                <f:if condition="{pagination.nextPage}">
+                    <li class="next">
+                        <f:widget.link action="index" arguments="{currentPage: pagination.nextPage}">next</f:widget.link>
+                    </li>
+                </f:if>
+            </ul>
+        </div>
+    </f:if>
 </f:section>

--- a/Tests/Behat/EmailContext.php
+++ b/Tests/Behat/EmailContext.php
@@ -6,91 +6,98 @@ namespace Networkteam\Util\Tests\Behat;
  ***************************************************************/
 
 use Behat\Behat\Context\BehatContext,
-	Behat\Behat\Event\ScenarioEvent;
+    Behat\Behat\Event\ScenarioEvent;
 use Behat\Gherkin\Node\TableNode;
 use Guzzle\Http\Client;
 use PHPUnit_Framework_Assert as Assert;
 
-class EmailContext extends BehatContext {
+class EmailContext extends BehatContext
+{
 
-	/**
-	 * @var Client
-	 */
-	protected $fakeSmtpClient;
+    /**
+     * @var Client
+     */
+    protected $fakeSmtpClient;
 
-	/**
-	 * @param array $parameters
-	 */
-	public function __construct(array $parameters) {
-		if (isset($parameters['fake_smtp_url'])) {
-			$this->fakeSmtpClient = new Client($parameters['fake_smtp_url']);
-		}
-	}
+    /**
+     * @param array $parameters
+     */
+    public function __construct(array $parameters)
+    {
+        if (isset($parameters['fake_smtp_url'])) {
+            $this->fakeSmtpClient = new Client($parameters['fake_smtp_url']);
+        }
+    }
 
-	/**
-	 * @BeforeScenario @email
-	 *
-	 * @param ScenarioEvent $event
-	 */
-	public function resetSmtpMessages(ScenarioEvent $event = NULL) {
-		$this->fakeSmtpClient->post('/reset')->send();
-	}
+    /**
+     * @BeforeScenario @email
+     *
+     * @param ScenarioEvent $event
+     */
+    public function resetSmtpMessages(ScenarioEvent $event = null)
+    {
+        $this->fakeSmtpClient->post('/reset')->send();
+    }
 
-	/**
-	 * @Given /^I empty all sent emails$/
-	 */
-	public function iEmptyAllSentEmails() {
-		$this->resetSmtpMessages();
-	}
+    /**
+     * @Given /^I empty all sent emails$/
+     */
+    public function iEmptyAllSentEmails()
+    {
+        $this->resetSmtpMessages();
+    }
 
-	/**
-	 * @Given /^I should have no emails$/
-	 */
-	public function iShouldHaveNoEmails() {
-		$messages = $this->fakeSmtpClient->get('/messages')->send()->json();
-		Assert::assertEmpty($messages, 'There should be no sent emails');
-	}
+    /**
+     * @Given /^I should have no emails$/
+     */
+    public function iShouldHaveNoEmails()
+    {
+        $messages = $this->fakeSmtpClient->get('/messages')->send()->json();
+        Assert::assertEmpty($messages, 'There should be no sent emails');
+    }
 
-	/**
-	 * @Then /^I should have the following emails:$/
-	 */
-	public function iShouldHaveTheFollowingEmails(TableNode $table) {
-		$messages = $this->fakeSmtpClient->get('/messages')->send()->json();
-		Assert::assertNotEmpty($messages, 'There should be at least one email');
+    /**
+     * @Then /^I should have the following emails:$/
+     */
+    public function iShouldHaveTheFollowingEmails(TableNode $table)
+    {
+        $messages = $this->fakeSmtpClient->get('/messages')->send()->json();
+        Assert::assertNotEmpty($messages, 'There should be at least one email');
 
-		$receivedMessages = array();
-		foreach ($messages as $message) {
-			if (preg_match('/<(.*?)>/', html_entity_decode($message['To']), $matches)) {
-				$to = $matches[1];
-			} else {
-				$to = $message['To'];
-			}
-			$receivedMessages[] = array(
-				'to' => $to,
-				'subject' => $message['Subject']
-			);
-		}
+        $receivedMessages = array();
+        foreach ($messages as $message) {
+            if (preg_match('/<(.*?)>/', html_entity_decode($message['To']), $matches)) {
+                $to = $matches[1];
+            } else {
+                $to = $message['To'];
+            }
+            $receivedMessages[] = array(
+                'to' => $to,
+                'subject' => $message['Subject']
+            );
+        }
 
-		$rows = $table->getHash();
-		foreach ($rows as $tableRow) {
-			Assert::assertContains($tableRow, $receivedMessages);
-		}
-	}
+        $rows = $table->getHash();
+        foreach ($rows as $tableRow) {
+            Assert::assertContains($tableRow, $receivedMessages);
+        }
+    }
 
-	/**
-	 * @param string $email
-	 * @return array The email message if found
-	 */
-	public function findEmailByRecipient($email) {
-		$messages = $this->fakeSmtpClient->get('/messages')->send()->json();
-		Assert::assertNotEmpty($messages, 'There should be at least one email');
-		foreach ($messages as $message) {
-			if (isset($message['To']) && strpos($message['To'], $email) !== FALSE) {
-				return $message;
-			}
-		}
-		// TODO Show other emails?
-		Assert::fail('No email for "' . $email . '" found');
-	}
+    /**
+     * @param string $email
+     * @return array The email message if found
+     */
+    public function findEmailByRecipient($email)
+    {
+        $messages = $this->fakeSmtpClient->get('/messages')->send()->json();
+        Assert::assertNotEmpty($messages, 'There should be at least one email');
+        foreach ($messages as $message) {
+            if (isset($message['To']) && strpos($message['To'], $email) !== false) {
+                return $message;
+            }
+        }
+        // TODO Show other emails?
+        Assert::fail('No email for "' . $email . '" found');
+    }
 
 }

--- a/Tests/Functional/Fixture/FixtureFactory.php
+++ b/Tests/Functional/Fixture/FixtureFactory.php
@@ -12,25 +12,25 @@ use Neos\Flow\Annotations as Flow;
  *
  * @Flow\Scope("singleton")
  */
-abstract class FixtureFactory {
+abstract class FixtureFactory
+{
 
-	/**
-	 * @var string
-	 */
-	protected $baseType = NULL;
+    /**
+     * @var string
+     */
+    protected $baseType = null;
 
-	/**
-	 * the identifier for objects in this factory
-	 * @var string
-	 */
-	protected $identifierPropertyName;
+    /**
+     * the identifier for objects in this factory
+     * @var string
+     */
+    protected $identifierPropertyName;
 
-	/**
-	 *
-	 * @var array
-	 */
-	protected $fixtureDefinitions = array(
-		/*
+    /**
+     *
+     * @var array
+     */
+    protected $fixtureDefinitions = array(/*
 		 * Example configuration
 		 *
 		'sfmService' => array(
@@ -38,189 +38,201 @@ abstract class FixtureFactory {
 			'identifier' => 'FooService'
 		)
 		 */
-	);
+    );
 
-	/**
-	 * @Flow\Inject
-	 * @var \Neos\Flow\Persistence\PersistenceManagerInterface
-	 */
-	protected $persistenceManager;
+    /**
+     * @Flow\Inject
+     * @var \Neos\Flow\Persistence\PersistenceManagerInterface
+     */
+    protected $persistenceManager;
 
-	/**
-	 * place property names to ignore in reflection setting
-	 *
-	 * @var array
-	 */
-	protected $ignoredProperties = array();
+    /**
+     * place property names to ignore in reflection setting
+     *
+     * @var array
+     */
+    protected $ignoredProperties = array();
 
-	/**
-	 * Instance cache for created objects identified by this->identifierPropertyName
-	 *
-	 * @var array
-	 */
-	protected $instances = array();
+    /**
+     * Instance cache for created objects identified by this->identifierPropertyName
+     *
+     * @var array
+     */
+    protected $instances = array();
 
-	/**
-	 *
-	 * @param string $objectName
-	 * @param array $overrideProperties
-	 * @return object
-	 */
-	public function buildObject($objectName, $overrideProperties = array(), $addObjectToPersistence = FALSE) {
-		if (!isset($this->fixtureDefinitions[$objectName])) {
-			throw new \Exception('Object name ' . $objectName . ' not configured in fixture definitions');
-		}
-		$properties = array_merge($this->fixtureDefinitions[$objectName], $overrideProperties);
-		$className = isset($properties['__type']) ? $properties['__type'] : $this->baseType;
-		unset($properties['__type']);
+    /**
+     *
+     * @param string $objectName
+     * @param array $overrideProperties
+     * @return object
+     */
+    public function buildObject($objectName, $overrideProperties = array(), $addObjectToPersistence = false)
+    {
+        if (!isset($this->fixtureDefinitions[$objectName])) {
+            throw new \Exception('Object name ' . $objectName . ' not configured in fixture definitions');
+        }
+        $properties = array_merge($this->fixtureDefinitions[$objectName], $overrideProperties);
+        $className = isset($properties['__type']) ? $properties['__type'] : $this->baseType;
+        unset($properties['__type']);
 
-		$object = new $className();
-		foreach ($properties as $propertyName => $propertyValue) {
-			if (\Neos\Utility\ObjectAccess::isPropertySettable($object, $propertyName) && !in_array($propertyName, $this->ignoredProperties)) {
-				\Neos\Utility\ObjectAccess::setProperty($object, $propertyName, $propertyValue);
-			}
-		}
+        $object = new $className();
+        foreach ($properties as $propertyName => $propertyValue) {
+            if (\Neos\Utility\ObjectAccess::isPropertySettable($object, $propertyName) && !in_array($propertyName,
+                    $this->ignoredProperties)) {
+                \Neos\Utility\ObjectAccess::setProperty($object, $propertyName, $propertyValue);
+            }
+        }
 
-		$this->setCustomProperties($object, $properties);
+        $this->setCustomProperties($object, $properties);
 
-		if ($addObjectToPersistence) {
-			$this->addObjectToPersistence($object);
-		}
+        if ($addObjectToPersistence) {
+            $this->addObjectToPersistence($object);
+        }
 
-		$this->instances[$this->createCacheIdentifier($properties[$this->identifierPropertyName])] = $object;
+        $this->instances[$this->createCacheIdentifier($properties[$this->identifierPropertyName])] = $object;
 
-		return $object;
-	}
+        return $object;
+    }
 
-	/**
-	 *
-	 * @param string $objectName
-	 * @param array $overrideProperties
-	 * @return object
-	 */
-	public function createObject($objectName, $overrideProperties = array()) {
-		$object = $this->buildObject($objectName, $overrideProperties, TRUE);
-		return $object;
-	}
+    /**
+     *
+     * @param string $objectName
+     * @param array $overrideProperties
+     * @return object
+     */
+    public function createObject($objectName, $overrideProperties = array())
+    {
+        $object = $this->buildObject($objectName, $overrideProperties, true);
+        return $object;
+    }
 
-	/**
-	 * @param object $object
-	 * @return void
-	 */
-	protected function addObjectToPersistence($object) {
-		$this->persistenceManager->add($object);
-	}
+    /**
+     * @param object $object
+     * @return void
+     */
+    protected function addObjectToPersistence($object)
+    {
+        $this->persistenceManager->add($object);
+    }
 
-	/**
-	 *
-	 * @param string $name
-	 * @param array $arguments
-	 * @return object
-	 */
-	public function __call($methodName, array $arguments) {
-		if (substr($methodName, 0, 5) === 'build' && strlen($methodName) > 6) {
-			$objectName = strtolower(substr($methodName, 5, 1)) . substr($methodName, 6);
-			$overrideProperties = isset($arguments[0]) ? $arguments[0] : array();
-			return $this->buildObject($objectName, $overrideProperties);
-		} elseif (substr($methodName, 0, 6) === 'create' && strlen($methodName) > 7) {
-			$objectName = strtolower(substr($methodName, 6, 1)) . substr($methodName, 7);
-			$overrideProperties = isset($arguments[0]) ? $arguments[0] : array();
-			return $this->findOrCreate($objectName, $overrideProperties);
-		}
-		trigger_error('Call to undefined method ' . get_class($this) . '::' . $methodName, E_USER_ERROR);
-	}
+    /**
+     *
+     * @param string $name
+     * @param array $arguments
+     * @return object
+     */
+    public function __call($methodName, array $arguments)
+    {
+        if (substr($methodName, 0, 5) === 'build' && strlen($methodName) > 6) {
+            $objectName = strtolower(substr($methodName, 5, 1)) . substr($methodName, 6);
+            $overrideProperties = isset($arguments[0]) ? $arguments[0] : array();
+            return $this->buildObject($objectName, $overrideProperties);
+        } elseif (substr($methodName, 0, 6) === 'create' && strlen($methodName) > 7) {
+            $objectName = strtolower(substr($methodName, 6, 1)) . substr($methodName, 7);
+            $overrideProperties = isset($arguments[0]) ? $arguments[0] : array();
+            return $this->findOrCreate($objectName, $overrideProperties);
+        }
+        trigger_error('Call to undefined method ' . get_class($this) . '::' . $methodName, E_USER_ERROR);
+    }
 
-	/**
-	 * Overwrite to implement own property definitions
-	 *
-	 * @param object $object
-	 * @param array $properties
-	 */
-	protected function setCustomProperties($object, $properties) {
-	}
+    /**
+     * Overwrite to implement own property definitions
+     *
+     * @param object $object
+     * @param array $properties
+     */
+    protected function setCustomProperties($object, $properties)
+    {
+    }
 
-	/**
-	 * Reset this fixture factory
-	 *
-	 * Implement in custom factories to reset instance caches.
-	 *
-	 * @return void
-	 */
-	public function reset() {
-		$this->instances = array();
-	}
+    /**
+     * Reset this fixture factory
+     *
+     * Implement in custom factories to reset instance caches.
+     *
+     * @return void
+     */
+    public function reset()
+    {
+        $this->instances = array();
+    }
 
-	/**
-	 * @param mixed $objectIdentification
-	 * @return object
-	 * @throws \InvalidArgumentException
-	 */
-	public function get($objectIdentification) {
-		if ($objectIdentification instanceof $this->baseType) {
-			$object = $objectIdentification;
-		} elseif (is_array($objectIdentification)) {
-			$object = $this->findOrCreate($this->getDefaultObjectName(), $objectIdentification);
-		} elseif (is_numeric($objectIdentification)) {
-			$object = $this->findOrCreate($this->getDefaultObjectName(), array('id' => $objectIdentification));
-		} elseif (is_string($objectIdentification)) {
-			$object = $this->findOrCreate($objectIdentification);
-		} else {
-			throw new \InvalidArgumentException('Expected object, fixture name, id or properties array got ' . gettype($objectIdentification));
-		}
+    /**
+     * @param mixed $objectIdentification
+     * @return object
+     * @throws \InvalidArgumentException
+     */
+    public function get($objectIdentification)
+    {
+        if ($objectIdentification instanceof $this->baseType) {
+            $object = $objectIdentification;
+        } elseif (is_array($objectIdentification)) {
+            $object = $this->findOrCreate($this->getDefaultObjectName(), $objectIdentification);
+        } elseif (is_numeric($objectIdentification)) {
+            $object = $this->findOrCreate($this->getDefaultObjectName(), array('id' => $objectIdentification));
+        } elseif (is_string($objectIdentification)) {
+            $object = $this->findOrCreate($objectIdentification);
+        } else {
+            throw new \InvalidArgumentException('Expected object, fixture name, id or properties array got ' . gettype($objectIdentification));
+        }
 
-		return $object;
-	}
+        return $object;
+    }
 
-	/**
-	 * @param string $objectName
-	 * @param $overrideProperties
-	 */
-	public function findOrCreate($objectName, $overrideProperties = array()) {
-		$object = NULL;
-		if (isset($overrideProperties[$this->identifierPropertyName])) {
-			$object = $this->getExistingObject($overrideProperties[$this->identifierPropertyName]);
-		} elseif (isset($this->fixtureDefinitions[$objectName][$this->identifierPropertyName])) {
-			$object = $this->getExistingObject($this->fixtureDefinitions[$objectName][$this->identifierPropertyName]);
-		}
+    /**
+     * @param string $objectName
+     * @param $overrideProperties
+     */
+    public function findOrCreate($objectName, $overrideProperties = array())
+    {
+        $object = null;
+        if (isset($overrideProperties[$this->identifierPropertyName])) {
+            $object = $this->getExistingObject($overrideProperties[$this->identifierPropertyName]);
+        } elseif (isset($this->fixtureDefinitions[$objectName][$this->identifierPropertyName])) {
+            $object = $this->getExistingObject($this->fixtureDefinitions[$objectName][$this->identifierPropertyName]);
+        }
 
-		if ($object !== NULL) {
-			return $object;
-		}
+        if ($object !== null) {
+            return $object;
+        }
 
-		return $this->createObject($objectName, $overrideProperties);
-	}
+        return $this->createObject($objectName, $overrideProperties);
+    }
 
-	/**
-	 * @param string $objectIdentifier
-	 * @return object
-	 */
-	protected function getExistingObject($objectIdentifier) {
-		$cacheIdentifier = $this->createCacheIdentifier($objectIdentifier);
+    /**
+     * @param string $objectIdentifier
+     * @return object
+     */
+    protected function getExistingObject($objectIdentifier)
+    {
+        $cacheIdentifier = $this->createCacheIdentifier($objectIdentifier);
 
-		if (isset($this->instances[$cacheIdentifier])) {
-			return $this->instances[$cacheIdentifier];
-		}
+        if (isset($this->instances[$cacheIdentifier])) {
+            return $this->instances[$cacheIdentifier];
+        }
 
-		return $this->persistenceManager->getObjectByIdentifier($objectIdentifier, $this->baseType);
-	}
+        return $this->persistenceManager->getObjectByIdentifier($objectIdentifier, $this->baseType);
+    }
 
-	/**
-	 * @param string $objectIdentifier
-	 * @return string
-	 */
-	protected function createCacheIdentifier($objectIdentifier) {
-		return md5($this->baseType . $objectIdentifier);
-	}
+    /**
+     * @param string $objectIdentifier
+     * @return string
+     */
+    protected function createCacheIdentifier($objectIdentifier)
+    {
+        return md5($this->baseType . $objectIdentifier);
+    }
 
-	/**
-	 * @return string
-	 */
-	protected function getDefaultObjectName() {
-		if ($this->fixtureDefinitions === array()) {
-			throw new \Exception('No fixture definitions in ' . gettype($this));
-		}
-		$objectNames = array_keys($this->fixtureDefinitions);
-		$defaultObjectName = $objectNames[0];
-		return $defaultObjectName;
-	}
+    /**
+     * @return string
+     */
+    protected function getDefaultObjectName()
+    {
+        if ($this->fixtureDefinitions === array()) {
+            throw new \Exception('No fixture definitions in ' . gettype($this));
+        }
+        $objectNames = array_keys($this->fixtureDefinitions);
+        $defaultObjectName = $objectNames[0];
+        return $defaultObjectName;
+    }
 }

--- a/Tests/Unit/Mail/MailMessage.php
+++ b/Tests/Unit/Mail/MailMessage.php
@@ -21,10 +21,10 @@ class MailMessage implements \Networkteam\Util\Mail\MailerMessageInterface
     protected $replyTo;
 
 
-	/**
-	 * @var array<MailHeader>
-	 */
-	protected array $headers;
+    /**
+     * @var array<MailHeader>
+     */
+    protected array $headers;
 
     /**
      * Returns the mimetype of the message(text/html)
@@ -73,9 +73,9 @@ class MailMessage implements \Networkteam\Util\Mail\MailerMessageInterface
     /**
      * @return array<MailHeader>
      */
-    public function getHeaders() : array
+    public function getHeaders(): array
     {
-		return $this->headers;
+        return $this->headers;
     }
 
     /**
@@ -107,11 +107,12 @@ class MailMessage implements \Networkteam\Util\Mail\MailerMessageInterface
         $this->replyTo = $replyTo;
     }
 
-	/**
-	 * @param array<string> $headers
-	 * @return void
-	 */
-	public function setHeaders(array $headers) : void {
-		$this->headers = $headers;
-	}
+    /**
+     * @param array<string> $headers
+     * @return void
+     */
+    public function setHeaders(array $headers): void
+    {
+        $this->headers = $headers;
+    }
 }

--- a/Tests/Unit/Mail/MailerTest.php
+++ b/Tests/Unit/Mail/MailerTest.php
@@ -13,73 +13,84 @@ use Psr\Log\LoggerInterface;
 class MailerTest extends UnitTestCase
 {
 
-	/**
-	 * @var \Neos\SwiftMailer\Message
-	 */
-	protected $mockMessage;
+    /**
+     * @var \Neos\SwiftMailer\Message
+     */
+    protected $mockMessage;
 
-	/**
-	 * @var \Networkteam\Util\Mail\MailerInterface
-	 */
-	protected $mailer;
+    /**
+     * @var \Networkteam\Util\Mail\MailerInterface
+     */
+    protected $mailer;
 
-	public function setUp(): void
-	{
-		parent::setUp();
-		$this->mockMessage = $this->getMockBuilder('Neos\SwiftMailer\Message')
-			->setMethods(array('setFrom', 'setTo', 'addCc', 'setBody', 'send', 'setSubject', 'getTo', 'getSubject', 'getRecipientIdentifier', 'setReplyTo'))
-			->getMock();
-		$this->mailer = new \Networkteam\Util\Mail\Mailer();
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->mockMessage = $this->getMockBuilder('Neos\SwiftMailer\Message')
+            ->setMethods(array(
+                'setFrom',
+                'setTo',
+                'addCc',
+                'setBody',
+                'send',
+                'setSubject',
+                'getTo',
+                'getSubject',
+                'getRecipientIdentifier',
+                'setReplyTo'
+            ))
+            ->getMock();
+        $this->mailer = new \Networkteam\Util\Mail\Mailer();
 
-		$this->mailer->setMessage($this->mockMessage);
+        $this->mailer->setMessage($this->mockMessage);
 
-		$logger = $this->getMockBuilder('Networkteam\Util\Log\MailerLoggerInterface')
-			->getMock();
+        $logger = $this->getMockBuilder('Networkteam\Util\Log\MailerLoggerInterface')
+            ->getMock();
 
-		$this->inject($this->mailer, 'logger', $logger);
-	}
+        $this->inject($this->mailer, 'logger', $logger);
+    }
 
-	/**
-	 * @@test
-	 */
-	public function mailerUsesAddCcForAddingRecipients()
-	{
-		$this->mockMessage->expects($this->exactly(2))
-			->method('addCc');
+    /**
+     * @@test
+     */
+    public function mailerUsesAddCcForAddingRecipients()
+    {
+        $this->mockMessage->expects($this->exactly(2))
+            ->method('addCc');
 
-		$this->mockMessage->expects($this->exactly(1))
-			->method('setReplyTo')
-			->with($this->equalTo('my-reply@example.com'));
+        $this->mockMessage->expects($this->exactly(1))
+            ->method('setReplyTo')
+            ->with($this->equalTo('my-reply@example.com'));
 
-		$mailMessage = new MailMessage();
-		$mailMessage->setRecipients(array(
-			'test1@example.com',
-			'test2@example.com',
-			'test3@example.com',
-		));
+        $mailMessage = new MailMessage();
+        $mailMessage->setRecipients(array(
+            'test1@example.com',
+            'test2@example.com',
+            'test3@example.com',
+        ));
 
-		$mailMessage->setHeaders([]);
+        $mailMessage->setHeaders([]);
 
-		$mailMessage->setReplyTo('my-reply@example.com');
+        $mailMessage->setReplyTo('my-reply@example.com');
 
-		$this->mailer->send($mailMessage);
-	}
+        $this->mailer->send($mailMessage);
+    }
 
-	/**
-	 * @@test
-	 */
-	public function mailerSkipsReplyToIfEmpty()
-	{
-		$this->mockMessage->expects($this->never())
-			->method('setReplyTo');
+    /**
+     * @@test
+     */
+    public function mailerSkipsReplyToIfEmpty()
+    {
+        $this->mockMessage->expects($this->never())
+            ->method('setReplyTo');
 
-		$mailMessage = new MailMessage();
-		$mailMessage->setRecipients(array(
-			'test1@example.com'
-		));
+        $mailMessage = new MailMessage();
+        $mailMessage->setRecipients(array(
+            'test1@example.com'
+        ));
 
-		$mailMessage->setHeaders([]);
+        $mailMessage->setHeaders([]);
 
-		$this->mailer->send($mailMessage);
-	}
+        $this->mailer->send($mailMessage);
+    }
 }

--- a/Tests/Unit/TypeConverter/JsonResourceTypeConverterTest.php
+++ b/Tests/Unit/TypeConverter/JsonResourceTypeConverterTest.php
@@ -11,80 +11,81 @@ use Neos\Flow\Tests\UnitTestCase;
 class JsonResourceTypeConverterTest extends UnitTestCase
 {
 
-	/**
-	 * @test
-	 */
-	public function canConvertReturnsTrueForCorrectValues()
-	{
-		$typeConverter = new \Networkteam\Util\TypeConverter\JsonResourceTypeConverter();
-		$result = $typeConverter->canConvertFrom(array(
-			'filename' => 'abc.csv',
-			'value' => 'data:abc',
-			'mime' => 'application/csv'
-		), 'Neos\Flow\ResourceManagement\PersistentResource');
+    /**
+     * @test
+     */
+    public function canConvertReturnsTrueForCorrectValues()
+    {
+        $typeConverter = new \Networkteam\Util\TypeConverter\JsonResourceTypeConverter();
+        $result = $typeConverter->canConvertFrom(array(
+            'filename' => 'abc.csv',
+            'value' => 'data:abc',
+            'mime' => 'application/csv'
+        ), 'Neos\Flow\ResourceManagement\PersistentResource');
 
-		$this->assertTrue($result);
-	}
+        $this->assertTrue($result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function canConvertReturnsFalseForMultipartValues()
-	{
-		$typeConverter = new \Networkteam\Util\TypeConverter\JsonResourceTypeConverter();
-		$result = $typeConverter->canConvertFrom(array(
-			'submittedFile' => array(
-				'filename' => 'abc.csv'
-			),
-			'tmp_name' => 'tmp_abc'
-		), 'Neos\Flow\ResourceManagement\PersistentResource');
+    /**
+     * @test
+     */
+    public function canConvertReturnsFalseForMultipartValues()
+    {
+        $typeConverter = new \Networkteam\Util\TypeConverter\JsonResourceTypeConverter();
+        $result = $typeConverter->canConvertFrom(array(
+            'submittedFile' => array(
+                'filename' => 'abc.csv'
+            ),
+            'tmp_name' => 'tmp_abc'
+        ), 'Neos\Flow\ResourceManagement\PersistentResource');
 
-		$this->assertFalse($result);
-	}
+        $this->assertFalse($result);
+    }
 
-	/**
-	 * @test
-	 */
-	public function convertFromBuildsResourceFromCorrectValues()
-	{
-		$content = 'My little pony';
+    /**
+     * @test
+     */
+    public function convertFromBuildsResourceFromCorrectValues()
+    {
+        $content = 'My little pony';
 
-		$mockResource = $this->getMockBuilder('Neos\Flow\ResourceManagement\PersistentResource')->getMock();
-		$mockResourceManager = $this->getMockBuilder('Neos\Flow\ResourceManagement\ResourceManager')->getMock();
+        $mockResource = $this->getMockBuilder('Neos\Flow\ResourceManagement\PersistentResource')->getMock();
+        $mockResourceManager = $this->getMockBuilder('Neos\Flow\ResourceManagement\ResourceManager')->getMock();
 
-		$typeConverter = new \Networkteam\Util\TypeConverter\JsonResourceTypeConverter();
-		$this->inject($typeConverter, 'resourceManager', $mockResourceManager);
+        $typeConverter = new \Networkteam\Util\TypeConverter\JsonResourceTypeConverter();
+        $this->inject($typeConverter, 'resourceManager', $mockResourceManager);
 
-		$mockResourceManager->expects($this->once())->method('importResourceFromContent')->with($content, 'file.txt')->will($this->returnValue($mockResource));
+        $mockResourceManager->expects($this->once())->method('importResourceFromContent')->with($content,
+            'file.txt')->will($this->returnValue($mockResource));
 
-		$result = $typeConverter->convertFrom(array(
-			'filename' => 'file.txt',
-			'value' => 'data:text/plain;base64,' . base64_encode($content),
-			'mime' => 'text/plain'
-		), 'Neos\Flow\ResourceManagement\PersistentResource');
+        $result = $typeConverter->convertFrom(array(
+            'filename' => 'file.txt',
+            'value' => 'data:text/plain;base64,' . base64_encode($content),
+            'mime' => 'text/plain'
+        ), 'Neos\Flow\ResourceManagement\PersistentResource');
 
-		$this->assertSame($mockResource, $result);
-	}
+        $this->assertSame($mockResource, $result);
+    }
 
-	/**
-	 * @test
-	 * @dataProvider
-	 */
-	public function convertFromBuildsReturnsErrorForInvalidValue()
-	{
-		$mockResourceManager = $this->getMockBuilder('Neos\Flow\ResourceManagement\ResourceManager')->getMock();
+    /**
+     * @test
+     * @dataProvider
+     */
+    public function convertFromBuildsReturnsErrorForInvalidValue()
+    {
+        $mockResourceManager = $this->getMockBuilder('Neos\Flow\ResourceManagement\ResourceManager')->getMock();
 
-		$typeConverter = new \Networkteam\Util\TypeConverter\JsonResourceTypeConverter();
-		$this->inject($typeConverter, 'resourceManager', $mockResourceManager);
+        $typeConverter = new \Networkteam\Util\TypeConverter\JsonResourceTypeConverter();
+        $this->inject($typeConverter, 'resourceManager', $mockResourceManager);
 
-		$mockResourceManager->expects($this->never())->method('importResourceFromContent');
+        $mockResourceManager->expects($this->never())->method('importResourceFromContent');
 
-		$result = $typeConverter->convertFrom(array(
-			'filename' => 'file.txt',
-			'value' => 'undefined',
-			'mime' => 'text/plain'
-		), 'Neos\Flow\ResourceManagement\PersistentResource');
+        $result = $typeConverter->convertFrom(array(
+            'filename' => 'file.txt',
+            'value' => 'undefined',
+            'mime' => 'text/plain'
+        ), 'Neos\Flow\ResourceManagement\PersistentResource');
 
-		$this->assertInstanceOf('Neos\Error\Messages\Error', $result);
-	}
+        $this->assertInstanceOf('Neos\Error\Messages\Error', $result);
+    }
 }


### PR DESCRIPTION
* Use static serviceContext as "source". What else should it be?
* Get rid of "PHP Warning" and introduce severity with "error"
* Remove "context", because every field is context.
* Drop the stacktrace, because it too very long (line gets cut off in Loki)
* Add additionalData. Our Sentry Client could then pass its EventId with it.